### PR TITLE
Reflect changes to parent repo: use zstd from source

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -41,7 +41,7 @@ elseif(DEFINED ENV{WASM_TARGET})
         message(FATAL_ERROR "Environment variable WASM_TARGET must be set to 'wasi' or 'emscripten'!")
     endif()
     include_directories("$ENV{IDEMZK_DIR}/openssl/include")
-    include_directories("$ENV{IDEMZK_DIR}/zstd-wasm/zstd/lib")
+    include_directories("$ENV{IDEMZK_DIR}/zstd/lib")
     # This might be wasi only?
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions -msimd128")
     set(ARCH_FLAGS -D__wasm__)


### PR DESCRIPTION
Use upstream zstd build instead of an external downstream wasm build.